### PR TITLE
Replacing the loop into a Thread wait when running in auto mode.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-sass "0.3.2-SNAPSHOT"
+(defproject lein-sass "0.3.6-SNAPSHOT"
   :description "SASS autobuilder plugin"
   :url "https://github.com/101loops/lein-sass"
   :license {:name "Eclipse Public License - v 1.0"

--- a/src/leiningen/render.clj
+++ b/src/leiningen/render.clj
@@ -2,7 +2,8 @@
   (:use leiningen.utils)
   (:require [clojure-watch.core :refer [start-watch]]
             [clojure.java.shell :as shell]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io])
+  (:import java.lang.Thread))
 
 (defn render
   [src-file dest-file {:keys [style source-maps]}]
@@ -29,5 +30,6 @@
                    :event-types [:create :modify :delete]
                    :callback (fn [_ _] (render-once! options))
                    :options {:recursive true}}])
-    (loop []
-      (recur))))
+    (let [t (Thread/currentThread)]
+      (locking t
+        (.wait t)))))


### PR DESCRIPTION
I created this PR because lein sass auto does take up a lot of CPU when I start it.

The directory watch spawns its own Thread to watch for file changes.
Thus the call will immediately return and enter the loop and does a recur
at full speed.
