### PR TITLE
Output error if there is one

### DIFF
--- a/src/leiningen/render.clj
+++ b/src/leiningen/render.clj
@@ -15,7 +15,7 @@
           opts [ "-t" sass-style src-path dest-path]
           add-opts (if source-maps ["-m"] [])]
       (println (str "  [sass] - " (.getName src-file)))
-      (apply shell/sh (concat ["sassc"] add-opts opts)))))
+      (println (:err (apply shell/sh (concat ["sassc"] add-opts opts)))))))
 
 (defn render-once!
   [options]


### PR DESCRIPTION
lein-sass swallows errors which is infuriating and take away a lot of the point of the "auto" feature. This change just dumps errors on stdout, increasing usability.
